### PR TITLE
Fix undefined index notice in update_description method

### DIFF
--- a/includes/class-wpm-taxonomies.php
+++ b/includes/class-wpm-taxonomies.php
@@ -286,7 +286,7 @@ class WPM_Taxonomies extends WPM_Object {
 			return;
 		}
 
-		$description = wpm_set_new_value( $this->description['old'], $value, $taxonomy_config['description'] );
+		$description = wpm_set_new_value( $this->description['old'] ?? array(), $value, $taxonomy_config['description'] );
 		if ( ! empty( $description ) ) {
 			$description = wp_unslash( $description );
 		}


### PR DESCRIPTION
Closes #248 

### Error
Warning: Undefined array key "old" in /var/www/html/wp-content/plugins/wp-multilang/includes/class-wpm-taxonomies.php on line 289

### Testing Instructions
The problem is that update_description can also be called when the insert path set $this->description (without the 'old' key). This happens when I create a new term programmatically and WordPress fires both the insert and update hooks.